### PR TITLE
[release-18.0] Release of `v18.0.2`

### DIFF
--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - name: Fail if Code Freeze is enabled
       run: |
-        exit 1
+        exit 0

--- a/changelog/18.0/18.0.2/changelog.md
+++ b/changelog/18.0/18.0.2/changelog.md
@@ -1,0 +1,6 @@
+# Changelog of Vitess v18.0.2
+
+### Release 
+#### General
+ * [release-18.0] Code Freeze for `v18.0.2` [#203](https://github.com/frouioui/vitess/pull/203)
+

--- a/changelog/18.0/18.0.2/release_notes.md
+++ b/changelog/18.0/18.0.2/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v18.0.2
+The entire changelog for this release can be found [here](https://github.com/frouioui/vitess/blob/main/changelog/18.0/18.0.2/changelog.md).
+
+The release includes 1 merged Pull Requests.
+
+Thanks to all our contributors: @frouioui
+


### PR DESCRIPTION
Includes the release notes and release commit for the `v18.0.2` release. Once this PR is merged, we will be able to tag `v18.0.2` on the merge commit.