### PR TITLE
[release-18.0] Bump to `v18.0.3-SNAPSHOT` after the `v18.0.2` release

### DIFF
--- a/go/vt/servenv/version.go
+++ b/go/vt/servenv/version.go
@@ -19,4 +19,4 @@ package servenv
 // DO NOT EDIT
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
-const versionName = "18.0.2"
+const versionName = "v18.0.3-SNAPSHOT"

--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.2</version>
+    <version>v18.0.3-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-client</artifactId>
 

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.2</version>
+    <version>v18.0.3-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-example</artifactId>
 

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.2</version>
+    <version>v18.0.3-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-grpc-client</artifactId>
 

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.2</version>
+    <version>v18.0.3-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-jdbc</artifactId>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.vitess</groupId>
   <artifactId>vitess-parent</artifactId>
-  <version>18.0.2</version>
+  <version>v18.0.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Vitess Java Client libraries [Parent]</name>


### PR DESCRIPTION
Includes the changes required to go back into dev mode ([release-18.0] Bump to `v18.0.3-SNAPSHOT` after the `v18.0.2` release) after the release of v18.0.2.