### PR TITLE
Copy `v19.0.0-RC1` release notes on `main`

### DIFF
--- a/changelog/19.0/19.0.0/changelog.md
+++ b/changelog/19.0/19.0.0/changelog.md
@@ -1,0 +1,14 @@
+# Changelog of Vitess v19.0.0
+
+### Other 
+#### Other
+ * add update go deps workflow [#220](https://github.com/frouioui/vitess/pull/220)
+### Release 
+#### General
+ * Copy `v18.0.2` release notes on `main` [#213](https://github.com/frouioui/vitess/pull/213)
+ * [release-19.0] Code Freeze for `v19.0.0-RC1` [#241](https://github.com/frouioui/vitess/pull/241)
+ * [release-19.0] Release of `v19.0.0-RC1` [#244](https://github.com/frouioui/vitess/pull/244)
+ * Copy `v19.0.0-RC1` release notes on `main` [#245](https://github.com/frouioui/vitess/pull/245)
+ * [release-19.0] Bump to `v19.0.0-SNAPSHOT` after the `v19.0.0-RC1` release [#247](https://github.com/frouioui/vitess/pull/247)
+ * Bump to `v20.0.0-SNAPSHOT` after the `v19.0.0-RC1` release [#249](https://github.com/frouioui/vitess/pull/249)
+

--- a/changelog/19.0/19.0.0/release_notes.md
+++ b/changelog/19.0/19.0.0/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v19.0.0
+The entire changelog for this release can be found [here](https://github.com/frouioui/vitess/blob/main/changelog/19.0/19.0.0/changelog.md).
+
+The release includes 7 merged Pull Requests.
+
+Thanks to all our contributors: @frouioui
+

--- a/changelog/19.0/README.md
+++ b/changelog/19.0/README.md
@@ -1,2 +1,4 @@
 ## v19.0
 * **[19.0.0](19.0.0)**
+	* [Changelog](19.0.0/changelog.md)
+	* [Release Notes](19.0.0/release_notes.md)


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-19.0` to keep release notes up-to-date after the `v19.0.0-RC1` release.