### PR TITLE
Copy `v19.0.0-RC2` release notes on `main`

### DIFF
--- a/changelog/19.0/19.0.0/changelog.md
+++ b/changelog/19.0/19.0.0/changelog.md
@@ -14,4 +14,9 @@
  * [release-19.0] Code Freeze for `v19.0.0-RC1` [#257](https://github.com/frouioui/vitess/pull/257)
  * Bump to `v20.0.0-SNAPSHOT` after the `v19.0.0-RC1` release [#258](https://github.com/frouioui/vitess/pull/258)
  * [release-19.0] Release of `v19.0.0-RC1` [#259](https://github.com/frouioui/vitess/pull/259)
+ * [release-19.0] Code Freeze for `v19.0.0-RC1` [#264](https://github.com/frouioui/vitess/pull/264)
+ * Bump to `v20.0.0-SNAPSHOT` after the `v19.0.0-RC1` release [#265](https://github.com/frouioui/vitess/pull/265)
+ * [release-19.0] Release of `v19.0.0-RC1` [#266](https://github.com/frouioui/vitess/pull/266)
+ * [release-19.0] Bump to `v19.0.0-SNAPSHOT` after the `v19.0.0-RC1` release [#268](https://github.com/frouioui/vitess/pull/268)
+ * [release-19.0] Code Freeze for `v19.0.0` [#270](https://github.com/frouioui/vitess/pull/270)
 

--- a/changelog/19.0/19.0.0/release_notes.md
+++ b/changelog/19.0/19.0.0/release_notes.md
@@ -1,7 +1,7 @@
 # Release of Vitess v19.0.0
 The entire changelog for this release can be found [here](https://github.com/frouioui/vitess/blob/main/changelog/19.0/19.0.0/changelog.md).
 
-The release includes 10 merged Pull Requests.
+The release includes 15 merged Pull Requests.
 
 Thanks to all our contributors: @frouioui
 


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-19.0` to keep release notes up-to-date after the `v19.0.0-RC2` release.