### PR TITLE
Copy `v19.0.1` release notes on `main`

### DIFF
--- a/changelog/19.0/19.0.1/changelog.md
+++ b/changelog/19.0/19.0.1/changelog.md
@@ -1,0 +1,2 @@
+# Changelog of Vitess v19.0.1
+

--- a/changelog/19.0/19.0.1/release_notes.md
+++ b/changelog/19.0/19.0.1/release_notes.md
@@ -1,0 +1,1 @@
+# Release of Vitess v19.0.1

--- a/changelog/19.0/README.md
+++ b/changelog/19.0/README.md
@@ -1,4 +1,8 @@
 ## v19.0
+* **[19.0.1](19.0.1)**
+	* [Changelog](19.0.1/changelog.md)
+	* [Release Notes](19.0.1/release_notes.md)
+
 * **[19.0.0](19.0.0)**
 	* [Changelog](19.0.0/changelog.md)
 	* [Release Notes](19.0.0/release_notes.md)


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-19.0` to keep release notes up-to-date after the `v19.0.1` release.