### PR TITLE
[main] Copy `v20.0.0` release notes

### DIFF
--- a/changelog/20.0/20.0.0/changelog.md
+++ b/changelog/20.0/20.0.0/changelog.md
@@ -14,4 +14,6 @@
  * [release-20.0-rc] Bump to `v20.0.0-SNAPSHOT` after the `v20.0.0-RC1` release [#324](https://github.com/frouioui/vitess/pull/324)
  * [release-20.0-rc] Release of `v20.0.0-RC2` [#330](https://github.com/frouioui/vitess/pull/330)
  * [release-20.0-rc] Bump to `v20.0.0-SNAPSHOT` after the `v20.0.0-RC2` release [#332](https://github.com/frouioui/vitess/pull/332)
+ * [release-20.0-rc] Release of `v20.0.0-RC3` [#335](https://github.com/frouioui/vitess/pull/335)
+ * [release-20.0-rc] Bump to `v20.0.0-SNAPSHOT` after the `v20.0.0-RC3` release [#337](https://github.com/frouioui/vitess/pull/337)
 

--- a/changelog/20.0/20.0.0/release_notes.md
+++ b/changelog/20.0/20.0.0/release_notes.md
@@ -339,7 +339,7 @@ Full details on the node v20.12.2 release can be found at https://nodejs.org/en/
 ------------
 The entire changelog for this release can be found [here](https://github.com/frouioui/vitess/blob/main/changelog/20.0/20.0.0/changelog.md).
 
-The release includes 12 merged Pull Requests.
+The release includes 14 merged Pull Requests.
 
 Thanks to all our contributors: @frouioui
 


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-20.0-rc` to keep release notes up-to-date after the `v20.0.0` release.