### PR TITLE
[main] Copy `v21.0.1` release notes

### DIFF
--- a/changelog/21.0/21.0.1/changelog.md
+++ b/changelog/21.0/21.0.1/changelog.md
@@ -1,0 +1,2 @@
+# Changelog of Vitess v21.0.1
+

--- a/changelog/21.0/21.0.1/release_notes.md
+++ b/changelog/21.0/21.0.1/release_notes.md
@@ -1,0 +1,1 @@
+# Release of Vitess v21.0.1

--- a/changelog/21.0/README.md
+++ b/changelog/21.0/README.md
@@ -1,4 +1,8 @@
 ## v21.0
+* **[21.0.1](21.0.1)**
+	* [Changelog](21.0.1/changelog.md)
+	* [Release Notes](21.0.1/release_notes.md)
+
 * **[21.0.0](21.0.0)**
 	* [Changelog](21.0.0/changelog.md)
 	* [Release Notes](21.0.0/release_notes.md)


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-21.0` to keep release notes up-to-date after the `v21.0.1` release.